### PR TITLE
ashmem: Validate ashmem memory with fops pointer

### DIFF
--- a/drivers/staging/android/ashmem.c
+++ b/drivers/staging/android/ashmem.c
@@ -808,11 +808,26 @@ static long ashmem_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	return ret;
 }
 
+static const struct file_operations ashmem_fops = {
+	.owner = THIS_MODULE,
+	.open = ashmem_open,
+	.release = ashmem_release,
+	.read = ashmem_read,
+	.llseek = ashmem_llseek,
+	.mmap = ashmem_mmap,
+	.unlocked_ioctl = ashmem_ioctl,
+	.compat_ioctl = ashmem_ioctl,
+};
+
+static struct miscdevice ashmem_misc = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "ashmem",
+	.fops = &ashmem_fops,
+};
+
 static int is_ashmem_file(struct file *file)
 {
-	char fname[256], *name;
-	name = dentry_path(file->f_dentry, fname, 256);
-	return strcmp(name, "/ashmem") ? 0 : 1;
+	return (file->f_op == &ashmem_fops);
 }
 
 int get_ashmem_file(int fd, struct file **filp, struct file **vm_file,
@@ -860,23 +875,6 @@ void put_ashmem_file(struct file *file)
 		fput(file);
 }
 EXPORT_SYMBOL(put_ashmem_file);
-
-static const struct file_operations ashmem_fops = {
-	.owner = THIS_MODULE,
-	.open = ashmem_open,
-	.release = ashmem_release,
-	.read = ashmem_read,
-	.llseek = ashmem_llseek,
-	.mmap = ashmem_mmap,
-	.unlocked_ioctl = ashmem_ioctl,
-	.compat_ioctl = ashmem_ioctl,
-};
-
-static struct miscdevice ashmem_misc = {
-	.minor = MISC_DYNAMIC_MINOR,
-	.name = "ashmem",
-	.fops = &ashmem_fops,
-};
 
 static int __init ashmem_init(void)
 {


### PR DESCRIPTION
Validate the ashmem memory entry against f_op pointer
rather then comparing its name with path of the dentry.

This is to avoid any invalid access to ashmem area in cases
where some one deliberately set the dentry name to /ashmem.

Change-Id: I74e50cd244f68cb13009cf2355e528485f4de34b
Signed-off-by: Sunil Khatri sunilkh@codeaurora.org
